### PR TITLE
Import GenericJSON

### DIFF
--- a/VatomFace3D.podspec
+++ b/VatomFace3D.podspec
@@ -22,5 +22,6 @@ Pod::Spec.new do |spec|
     spec.dependency 'Nuke'
     spec.dependency 'FLAnimatedImage'
     spec.dependency 'NVActivityIndicatorView'
-
+    spec.dependency 'GenericJSON'
+    
 end

--- a/VatomFace3D.podspec
+++ b/VatomFace3D.podspec
@@ -3,12 +3,12 @@ Pod::Spec.new do |spec|
 
     # Pod info
     spec.name                   = 'VatomFace3D'
-    spec.version                = '1.0.5'
+    spec.version                = '1.0.6'
     spec.license                = { :type => 'ISC' }
     spec.author                 = { 'BLOCKv' => 'developer.blockv.io' }
     spec.homepage               = 'https://github.com/BLOCKvIO/3D-Face'
     spec.summary                = 'This vAtom face can plug into the SDKs to render 3D content in either binary glTF or V3D format.'
-    spec.source                 = { :git => 'https://github.com/BLOCKvIO/3D-Face.git', :tag => '1.0.5' }
+    spec.source                 = { :git => 'https://github.com/BLOCKvIO/3D-Face.git', :tag => '1.0.6' }
     spec.source_files           = 'ios/*.{swift}'
     spec.resources              = 'webapp/**'
     spec.swift_version          = '4.0'

--- a/VatomFace3D.podspec
+++ b/VatomFace3D.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |spec|
 
     # Pod info
     spec.name                   = 'VatomFace3D'
-    spec.version                = '1.0.6'
+    spec.version                = '2.0.0'
     spec.license                = { :type => 'ISC' }
     spec.author                 = { 'BLOCKv' => 'developer.blockv.io' }
     spec.homepage               = 'https://github.com/BLOCKvIO/3D-Face'

--- a/VatomFace3D.podspec
+++ b/VatomFace3D.podspec
@@ -3,12 +3,12 @@ Pod::Spec.new do |spec|
 
     # Pod info
     spec.name                   = 'VatomFace3D'
-    spec.version                = '1.0.4'
+    spec.version                = '1.0.5'
     spec.license                = { :type => 'ISC' }
     spec.author                 = { 'BLOCKv' => 'developer.blockv.io' }
     spec.homepage               = 'https://github.com/BLOCKvIO/3D-Face'
     spec.summary                = 'This vAtom face can plug into the SDKs to render 3D content in either binary glTF or V3D format.'
-    spec.source                 = { :git => 'https://github.com/BLOCKvIO/3D-Face.git', :tag => '1.0.4' }
+    spec.source                 = { :git => 'https://github.com/BLOCKvIO/3D-Face.git', :tag => '1.0.5' }
     spec.source_files           = 'ios/*.{swift}'
     spec.resources              = 'webapp/**'
     spec.swift_version          = '4.0'

--- a/android/face3d/build.gradle
+++ b/android/face3d/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
 def libraryGroupId = 'io.blockv.faces'
 def libraryArtifactId = 'face3d'
-def libraryVersion = '1.0.6'
+def libraryVersion = '2.0.0'
 
 task sourceJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/android/face3d/build.gradle
+++ b/android/face3d/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
 def libraryGroupId = 'io.blockv.faces'
 def libraryArtifactId = 'face3d'
-def libraryVersion = '1.0.5'
+def libraryVersion = '1.0.6'
 
 task sourceJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/ios/Face3D.swift
+++ b/ios/Face3D.swift
@@ -11,6 +11,7 @@ import FLAnimatedImage
 import Nuke
 import NVActivityIndicatorView
 import WebKit
+import GenericJSON
 
 public class Face3D : FaceView, WKScriptMessageHandler, WKNavigationDelegate {
     

--- a/ios/FaceModel+JSON.swift
+++ b/ios/FaceModel+JSON.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import BLOCKv
+import GenericJSON
 
 extension FaceModel {
     

--- a/ios/JSON+Serialization.swift
+++ b/ios/JSON+Serialization.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import BLOCKv
+import GenericJSON
 
 extension JSON {
     

--- a/ios/VatomModel+JSON.swift
+++ b/ios/VatomModel+JSON.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import BLOCKv
+import GenericJSON
 
 extension VatomModel {
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockv/3d-face",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockv/3d-face",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "This vAtom face can plug into the SDKs to render 3D content in either binary glTF or V3D format.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockv/3d-face",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "This vAtom face can plug into the SDKs to render 3D content in either binary glTF or V3D format.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockv/3d-face",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "This vAtom face can plug into the SDKs to render 3D content in either binary glTF or V3D format.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
The type `JSON` is now defined in a dependency `GenericJSON` rather than directly in the BLOCKv SDK source.

Will this require a major version bump on this face?